### PR TITLE
Make it possible to run citychef outside a notebook.

### DIFF
--- a/citychef/osm.py
+++ b/citychef/osm.py
@@ -1,9 +1,19 @@
-from halo import HaloNotebook as Halo
 from lxml import etree as et
 import os
 import pandas as pd
 import gzip
+import halo
 
+def Halo(*args, **kw):
+    ipython = False
+    try:
+        get_ipython()
+        ipython = True
+    except NameError:
+        pass
+    if ipython:
+        return halo.HaloNotebook(*args, **kw)
+    return halo.Halo(*args, **kw)
 
 def is_xml(location):
     return location.lower().endswith(".xml")
@@ -14,7 +24,7 @@ def is_gzip(location):
 
 
 def create_local_dir(directory):
-    if not os.path.exists(directory):
+    if directory != "" and not os.path.exists(directory):
         print('Creating {}'.format(directory))
         os.makedirs(directory)
 
@@ -31,6 +41,7 @@ def xml_content(content):
     xml_version = b'<?xml version="1.0" encoding="UTF-8"?>'
     tree = xml_tree(content)
     return xml_version + tree
+
 
 
 def write_content(content, location, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ geopandas==0.6.1
 matplotlib==3.1.1
 scipy==1.3.0
 scikit_learn==0.22.2.post1
+halo==0.0.29
+lxml==4.5.1
+ipywidgets==7.5.1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+setuptools.setup(
+    name="citychef",
+    version="0.0.1",
+    author="Arup City Modelling Lab",
+    author_email="citymodelling@arup.com",
+    description="Randomly generate a city, and output statistical data about it.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/fredshone/citychef",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)


### PR DESCRIPTION
Add a setup.py, to allow citychef to be installed as a library.
Remove the dependency on ipython introduced by the explicit use of
HaloNotebook.
Add missing dependencies to requirements.txt.